### PR TITLE
Add flag to include dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,9 @@ jobs:
         if: ${{ matrix.lint }}
 
       - run: mix test
+
+      - run: mix kudos.generate
+
+      - run: mix kudos.generate --dry-run
+
+      - run: mix kudos.generate --include-dev-deps

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Print licenses to console:
 
 `mix kudos.generate --dry-run`
 
+Including dev dependencies:
+
+`mix kudos.generate --include-dev-deps`
+
 ## Documentation
 
 [https://hexdocs.pm/kudos](https://hexdocs.pm/kudos).

--- a/lib/kudos.ex
+++ b/lib/kudos.ex
@@ -14,9 +14,15 @@ defmodule Kudos do
       iex> Kudos.generate() |> String.length()
       219
 
+      iex> Kudos.generate(false) |> String.length()
+      219
+
+      iex> Kudos.generate(true) |> String.length()
+      19050
+
   """
-  def generate do
-    load_deps_meta_data()
+  def generate(include_dev_deps \\ false) do
+    load_deps_meta_data(include_dev_deps)
     |> Enum.reduce(header(), fn meta_data, resp ->
       resp <> format(meta_data)
     end)
@@ -94,7 +100,7 @@ defmodule Kudos do
     "[#{key}](#{value})"
   end
 
-  defp load_deps_meta_data() do
+  defp load_deps_meta_data(include_dev_deps) do
     Mix.Dep.load_on_environment([])
     |> Enum.map(fn dep ->
       Mix.Dep.in_dependency(dep, fn _ ->
@@ -103,7 +109,7 @@ defmodule Kudos do
             :umbrella
 
           false ->
-            case is_prod?(dep) do
+            case is_prod?(dep) || include_dev_deps do
               false ->
                 :dev
 

--- a/lib/kudos.ex
+++ b/lib/kudos.ex
@@ -109,7 +109,7 @@ defmodule Kudos do
             :umbrella
 
           false ->
-            case is_prod?(dep) || include_dev_deps do
+            case include_dev_deps || is_prod?(dep) do
               false ->
                 :dev
 

--- a/lib/mix/tasks/kudos.generate.ex
+++ b/lib/mix/tasks/kudos.generate.ex
@@ -8,7 +8,8 @@ defmodule Mix.Tasks.Kudos.Generate do
     IO.puts("Generating Licenses file...")
 
     resp =
-      Kudos.generate()
+      include_dev_deps?(args)
+      |> Kudos.generate()
       |> handle_licenses(dry_run?(args))
 
     case resp do
@@ -28,5 +29,9 @@ defmodule Mix.Tasks.Kudos.Generate do
 
   defp dry_run?(args) do
     Enum.member?(args, "--dry-run")
+  end
+
+  defp include_dev_deps?(args) do
+    Enum.member?(args, "--include-dev-deps")
   end
 end


### PR DESCRIPTION
As discussed earlier and will close #11 this PR add a flag for including development dependencies in the generation process.

- Added the flag
- Added the docs
- Added additional tests in the action